### PR TITLE
[#73] Upload `seed.sh` to release assets.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Upload seed.sh to release
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2
+        with:
+          files: seed.sh
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,9 @@ BUILDX_PLATFORMS=linux/arm64 DOCKER_DEFAULT_PLATFORM=linux/arm64 tests/bats/node
 - Pushes `canary` tag to DockerHub on main branch
 
 **release.yml** - Runs on Git tags:
-- Drafts release notes using release-drafter
+- Drafts release notes using release-drafter with CalVer version
 - Builds and pushes versioned + `latest` tags to DockerHub
+- Uploads `seed.sh` as a release asset
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -101,11 +101,13 @@ Versions are following versions of the [upstream image](https://hub.docker.com/r
 
 Releases are scheduled to occur at a minimum of once per month.
 
-This image is built by DockerHub via an automated build and tagged as follows:
+This image is built by GitHub Actions and tagged as follows:
 
 - `YY.m.patch` tag - when release tag is published on GitHub.
 - `latest` - when release tag is published on GitHub.
 - `canary` - on every push to `main` branch
+
+The `seed.sh` script is automatically uploaded as a release asset and can be downloaded from the latest release.
 
 ### Dependencies update
 

--- a/seed.sh
+++ b/seed.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 ##
-# Seed image with a database from file.
+# Seed image with a database from a file.
 # @see https://github.com/drevops/mariadb-drupal-data/blob/main/seed.sh
 #
-# The seeding process has 3-phases:
+# The seeding process has 3 phases:
 # 1. Create extracted DB files by starting a temporary container and importing the database.
 # 2. Build a new image from the base image and extracted DB files.
 # 3. Start a container from the new image and verify that the database was imported.
@@ -18,10 +18,10 @@
 set -eu
 [ -n "${DEBUG:-}" ] && set -x
 
-# Database dump file as a first argument to the script.
+# Database dump file as the first argument to the script.
 DB_FILE="${DB_FILE:-$1}"
 
-# Destination image as a second argument to the script.
+# Destination image as the second argument to the script.
 DST_IMAGE="${DST_IMAGE:-$2}"
 
 # Base image to start with.
@@ -30,7 +30,7 @@ DST_IMAGE="${DST_IMAGE:-$2}"
 BASE_IMAGE="${BASE_IMAGE:-drevops/mariadb-drupal-data:latest}"
 
 # Docker target platform architecture.
-# Note that some shells report platform incorrectly. In such cases, run
+# Note that some shells report the platform incorrectly. In such cases, run
 # as `DOCKER_DEFAULT_PLATFORM=linux/amd64 ./seed.sh path/to/db.sql myorg/myimage:latest`
 DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-}"
 
@@ -56,8 +56,8 @@ fail() { [ -z "${TERM_NO_COLOR:-}" ] && tput colors >/dev/null 2>&1 && printf "\
 note() { printf "       %s\n" "$1"; }
 # @formatter:on
 
-[ -z "${DB_FILE}" ] && fail "Path to the database dump file must be provided as a first argument." && exit 1
-[ -z "${DST_IMAGE}" ] && fail "Destination docker image name must be provided as a second argument." && exit 1
+[ -z "${DB_FILE}" ] && fail "Path to the database dump file must be provided as the first argument." && exit 1
+[ -z "${DST_IMAGE}" ] && fail "Destination Docker image name must be provided as the second argument." && exit 1
 [ ! -f "${DB_FILE}" ] && fail "Specified database dump file ${DB_FILE} does not exist." && exit 1
 [ "${BASE_IMAGE##*/}" = "$BASE_IMAGE" ] && fail "${BASE_IMAGE} should be in a format myorg/myimage." && exit 1
 [ "${DST_IMAGE##*/}" = "$DST_IMAGE" ] && fail "${DST_IMAGE} should be in a format myorg/myimage." && exit 1
@@ -114,12 +114,12 @@ wait_for_db_service() {
 
   echo -n "       Waiting for the service to become ready."
   if ! docker exec "${user[@]}" -i "${cid}" sh -c "until nc -z localhost 3306; do sleep 1; echo -n .; done; echo"; then
-    fail "MYSQL service did not start successfully."
+    fail "MySQL service did not start successfully."
     log_container "${cid}"
     return 1
   fi
   log_container "${cid}"
-  pass "MYSQL is running."
+  pass "MySQL is running."
 }
 
 assert_db_system_tables_present() {
@@ -191,7 +191,7 @@ if [ -n "${DOCKER_DEFAULT_PLATFORM}" ]; then
   task "Source platform architecture: ${DOCKER_DEFAULT_PLATFORM}"
 fi
 
-# Normalise image - add ":latest" if tag was not provided.
+# Normalize image - add ":latest" if tag was not provided.
 [ -n "${DST_IMAGE##*:*}" ] && DST_IMAGE="${DST_IMAGE}:latest"
 note "Destination image: ${DST_IMAGE}"
 note "Destination platform(s): ${DESTINATION_PLATFORMS}"
@@ -234,7 +234,7 @@ pass "Updated permissions on the seeded database files."
 task "Copy expanded database files to host"
 mkdir -p "${TMP_STRUCTURE_DIR}"
 docker cp "${cid}":/home/db-data/. "${TMP_STRUCTURE_DIR}/" >/dev/null
-[ ! -d "${TMP_STRUCTURE_DIR}/mysql" ] && fail "Unable to copy expanded database files to host " && ls -al "${TMP_STRUCTURE_DIR}" && exit 1
+[ ! -d "${TMP_STRUCTURE_DIR}/mysql" ] && fail "Unable to copy expanded database files to host" && ls -al "${TMP_STRUCTURE_DIR}" && exit 1
 pass "Copied expanded database files to host"
 
 stop_container "${cid}"


### PR DESCRIPTION
Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - seed.sh is now automatically attached to releases and downloadable from the latest release page.

- Documentation
  - Updated build description to GitHub Actions and noted seed.sh availability as a release asset.
  - Added details about dependency update releases and canary links.

- Style
  - Improved seed script messages for clarity and consistent capitalization; no behavioral changes.

- Chores
  - Enhanced release process to auto-draft notes with calendar versioning and upload release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->